### PR TITLE
Update endpoint url

### DIFF
--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -4,7 +4,7 @@ import { ApolloClient, ApolloProvider, InMemoryCache } from "@apollo/client";
 import { AppRoutes } from "@/routes/AppRoutes";
 
 const client = new ApolloClient({
-  uri: "http://localhost:8080/graphql",
+  uri: "https://beyondfootsteps-api.onrender.com/graphql",
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
This pull request updates the GraphQL API endpoint in the Apollo Client configuration to point to the production server instead of the local development server.

- Changed the `uri` in the Apollo Client setup within `src/pages/main.tsx` from the local address to the production API endpoint (`https://beyondfootsteps-api.onrender.com/graphql`).