### PR TITLE
fix: update GraphQL endpoint URI to production server

### DIFF
--- a/src/pages/main.tsx
+++ b/src/pages/main.tsx
@@ -5,7 +5,7 @@ import { AppRoutes } from "@/routes/AppRoutes";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 const client = new ApolloClient({
-  uri: "http://localhost:8080/graphql",
+  uri: "https://advisory-jacquie-ezequielperez-26d09b4e.koyeb.app/graphql",
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
This pull request updates the GraphQL endpoint used by the Apollo client in the `src/pages/main.tsx` file. The change replaces the local development server URL with a production deployment URL.

Configuration update:

* Changed the Apollo client `uri` from `"http://localhost:8080/graphql"` to the production endpoint `"https://advisory-jacquie-ezequielperez-26d09b4e.koyeb.app/graphql"` in `src/pages/main.tsx`.