### PR TITLE
fix: update text alignment property in Selector component for better …

### DIFF
--- a/src/components/selectorBar/styles.ts
+++ b/src/components/selectorBar/styles.ts
@@ -13,7 +13,7 @@ export const Selector = styled.select<{
   font-size: 0.9rem;
   font-weight: 600;
   color: #333333;
-  text-align: center;
+  text-align-last: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
This pull request makes a minor style adjustment to the `Selector` component to improve text alignment in the dropdown.

* Changed the CSS property from `text-align: center` to `text-align-last: center` in `src/components/selectorBar/styles.ts` to ensure the last line of text in the select element is centered