### PR TITLE
Develop

### DIFF
--- a/src/components/selectorBar/styles.ts
+++ b/src/components/selectorBar/styles.ts
@@ -13,7 +13,7 @@ export const Selector = styled.select<{
   font-size: 0.9rem;
   font-weight: 600;
   color: #333333;
-  text-align: center;
+  text-align-last: center;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
This pull request makes a minor adjustment to the styling of the `Selector` component. The change updates the text alignment property to use `text-align-last` for centering the last line of text in the select element.

* Changed the CSS property from `text-align: center;` to `text-align-last: center;` in the `Selector` styled component in `src/components/selectorBar/styles.ts`. (It was not working on iOS phones before)