### PR TITLE
feat: update navigation links to point to the dashboard and add Scrol…

### DIFF
--- a/src/components/layout/navbar/general/index.tsx
+++ b/src/components/layout/navbar/general/index.tsx
@@ -38,8 +38,8 @@ export const GeneralNavBar = () => {
         <LinkMenu>
           <MenuElement open={showInMobile}>
             <LinkElement
-              to="/"
-              $active={currentPath === "/"}
+              to="/dashboard"
+              $active={currentPath === "/dashboard"}
               $linearGradient="linear-gradient(90deg, #232526, #414345);"
               onClick={handleLinkClick}
             >

--- a/src/components/layout/navbar/specific/index.tsx
+++ b/src/components/layout/navbar/specific/index.tsx
@@ -29,7 +29,7 @@ export const SpecificNavBar = () => {
     <LayoutNavbar>
       <MenuContainer>
         <LogoAndMobileMenu>
-          <LogoLayout onClick={() => navigate("/")} src={logo} />
+          <LogoLayout onClick={() => navigate("/dashboard")} src={logo} />
           <MenuLayout onClick={() => setShowInMobile(!showInMobile)}>
             ☰
           </MenuLayout>

--- a/src/hooks/useScrollUp/index.tsx
+++ b/src/hooks/useScrollUp/index.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+    
+  }, [pathname]);
+
+  return null; 
+}

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -1,4 +1,5 @@
 import { MainLayout } from "@/components/layout";
+import { ScrollToTop } from "@/hooks/useScrollUp";
 import AboutUs from "@/pages/aboutus";
 import { AsylumDecisions } from "@/pages/asylumDecisions";
 import { AsylumRequests } from "@/pages/asylumRequests";
@@ -11,17 +12,18 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 export const AppRoutes = () => {
   return (
     <BrowserRouter>
-      <Routes>
-        <Route element={<MainLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/requests" element={<AsylumRequests />} />
-          <Route path="/decisions" element={<AsylumDecisions />} />
-          <Route path="/resettlements" element={<ResettlementSummary />} />
-        </Route>
+      <ScrollToTop/>
+        <Routes>
+          <Route element={<MainLayout />}>
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/requests" element={<AsylumRequests />} />
+            <Route path="/decisions" element={<AsylumDecisions />} />
+            <Route path="/resettlements" element={<ResettlementSummary />} />
+          </Route>
+          <Route path="/" element={<Home />} />
           <Route path="/aboutus" element={<AboutUs />} />
-          <Route path="/home" element={<Home />} />
           <Route path="*" element={<NotFound />} />
-      </Routes>
+        </Routes>
     </BrowserRouter>
   );
 };


### PR DESCRIPTION
This pull request updates the app's routing and navigation to make `/dashboard` the main landing page instead of `/`, and introduces automatic scroll-to-top behavior when navigating between routes. The changes ensure consistency in navigation across the app and improve user experience by resetting the scroll position on route changes.

**Routing and Navigation Updates:**

* Changed the main dashboard route from `/` to `/dashboard` in `AppRoutes.tsx`, and updated all navigation links and logo redirects to point to `/dashboard` instead of `/` for consistency. [[1]](diffhunk://#diff-6b2aab9604475c52f1a82f457ba2f7a3b3ce5c49381691de250b764897ce78b8R15-L22) [[2]](diffhunk://#diff-9ecffeb4962537b4453fa34b77c9ee78d6b0a68280a6cdbac4e4d2cdb9fb857bL41-R42) [[3]](diffhunk://#diff-6d8e9609b58e0dd12cad1607f963deec4c2254ee5177156e35ca035fa31a6c21L32-R32)
* Moved the home page route from `/home` to `/`, making `/dashboard` the default landing page and `/` the dedicated home page.

**User Experience Improvements:**

* Added a new `ScrollToTop` hook that automatically scrolls the page to the top whenever the route changes, improving navigation experience. [[1]](diffhunk://#diff-5b82266faddbe29776bde8796574d90482c26b4e9f75a7b9d4f04733a4f381c1R1-R13) [[2]](diffhunk://#diff-6b2aab9604475c52f1a82f457ba2f7a3b3ce5c49381691de250b764897ce78b8R2) [[3]](diffhunk://#diff-6b2aab9604475c52f1a82f457ba2f7a3b3ce5c49381691de250b764897ce78b8R15-L22)