### PR TITLE
feat: update navigation links to point to the dashboard in navbar com…

### DIFF
--- a/src/components/layout/navbar/general/index.tsx
+++ b/src/components/layout/navbar/general/index.tsx
@@ -30,7 +30,7 @@ export const GeneralNavBar = () => {
     <LayoutNavbar>
       <MenuContainer>
         <LogoAndMobileMenu>
-          <LogoLayout onClick={() => navigate("/")} src={logo} />
+          <LogoLayout onClick={() => navigate("/dashboard")} src={logo} />
           <MenuLayout onClick={() => setShowInMobile(!showInMobile)}>
             ☰
           </MenuLayout>

--- a/src/components/layout/navbar/specific/index.tsx
+++ b/src/components/layout/navbar/specific/index.tsx
@@ -37,8 +37,8 @@ export const SpecificNavBar = () => {
         <LinkMenu>
           <MenuElement open={showInMobile}>
             <LinkElement
-              to="/"
-              $active={currentPath === "/"}
+              to="/dashboard"
+              $active={currentPath === "/dashboard"}
               $linearGradient="linear-gradient(90deg, #232526, #414345);"
               onClick={handleLinkClick}
             >

--- a/src/pages/home/navbar/index.tsx
+++ b/src/pages/home/navbar/index.tsx
@@ -22,6 +22,13 @@ export const HomeNavbar = () => {
               $active={currentPath === "/"}
               $linearGradient="linear-gradient(90deg, #232526, #414345);"
             >
+              Home
+            </LinkElement>
+            <LinkElement
+              to="/dashboard"
+              $active={currentPath === "/dashboard"}
+              $linearGradient="linear-gradient(90deg, #232526, #414345);"
+            >
               Maps
             </LinkElement>
             <LinkElement

--- a/src/pages/notFound/index.tsx
+++ b/src/pages/notFound/index.tsx
@@ -27,7 +27,7 @@ export const NotFound = () => {
             back on track to explore humanitarian data.
           </ErrorDescription>
 
-          <BackButton as={Link} to="/">
+          <BackButton as={Link} to="/dashboard">
             Return to Dashboard
           </BackButton>
         </NotFoundContent>


### PR DESCRIPTION
This pull request updates navigation throughout the app to use `/dashboard` as the main landing page instead of `/`. The changes ensure that links, navigation bars, and buttons now direct users to the dashboard, providing a more consistent user experience.

Navigation updates:

* Changed the logo click in `GeneralNavBar` to navigate to `/dashboard` instead of `/`.
* Updated the main menu link in `SpecificNavBar` to point to `/dashboard` and set its active state accordingly.
* Added a new "Home" link and updated the "Maps" link in `HomeNavbar` so that "Maps" now points to `/dashboard` and reflects the correct active state.
* Modified the "Return to Dashboard" button in the `NotFound` page to navigate to `/dashboard` instead of `/`.