### PR TITLE
fix: update navigation links in GeneralNavBar and SpecificNavBar to p…

### DIFF
--- a/src/components/layout/navbar/general/index.tsx
+++ b/src/components/layout/navbar/general/index.tsx
@@ -30,7 +30,7 @@ export const GeneralNavBar = () => {
     <LayoutNavbar>
       <MenuContainer>
         <LogoAndMobileMenu>
-          <LogoLayout onClick={() => navigate("/dashboard")} src={logo} />
+          <LogoLayout onClick={() => navigate("/")} src={logo} />
           <MenuLayout onClick={() => setShowInMobile(!showInMobile)}>
             ☰
           </MenuLayout>

--- a/src/components/layout/navbar/specific/index.tsx
+++ b/src/components/layout/navbar/specific/index.tsx
@@ -29,7 +29,7 @@ export const SpecificNavBar = () => {
     <LayoutNavbar>
       <MenuContainer>
         <LogoAndMobileMenu>
-          <LogoLayout onClick={() => navigate("/dashboard")} src={logo} />
+          <LogoLayout onClick={() => navigate("/")} src={logo} />
           <MenuLayout onClick={() => setShowInMobile(!showInMobile)}>
             ☰
           </MenuLayout>


### PR DESCRIPTION
This pull request updates the navigation behavior for both the general and specific navigation bars. The most important change is that clicking the logo now routes users to the homepage instead of the dashboard.

Navigation updates:

* Changed the `onClick` handler for the `LogoLayout` component in `src/components/layout/navbar/general/index.tsx` to navigate to `/` instead of `/dashboard`.
* Changed the `onClick` handler for the `LogoLayout` component in `src/components/layout/navbar/specific/index.tsx` to navigate to `/` instead of `/dashboard`.